### PR TITLE
Reduce default buffer size, keep old constructor for HTMLSchema

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.yahoo.tagchowder</groupId>
         <artifactId>tagchowder</artifactId>
-        <version>2.0.15</version>
+        <version>2.0.16</version>
     </parent>
     <artifactId>tagchowder.core</artifactId>
     <name>${project.artifactId}</name>

--- a/core/src/main/java/com/yahoo/tagchowder/Parser.java
+++ b/core/src/main/java/com/yahoo/tagchowder/Parser.java
@@ -72,7 +72,7 @@ public class Parser extends DefaultHandler implements ScanHandler, XMLReader, Le
     private Logger logger = LoggerFactory.getLogger(Parser.class);
 
 
-    private int defaultBufferSize = 20000;
+    private int defaultBufferSize = 2000;
     // Default values for feature flags
 
     private static final boolean DEFAULT_NAMESPACES = true;

--- a/core/templates/HTMLSchema.java
+++ b/core/templates/HTMLSchema.java
@@ -30,6 +30,17 @@ public class HTMLSchema extends Schema implements HTMLModels {
 
 	/**
 	 * Returns a newly constructed HTMLSchema object independent of any existing ones.
+	 */
+	public HTMLSchema() {
+		// Enable JVM string intern.
+		setUseIntern(true);
+		// Start of Schema calls
+		@@SCHEMA_CALLS@@
+		// End of Schema calls
+	}
+
+	/**
+	 * Returns a newly constructed HTMLSchema object independent of any existing ones.
 	 * @param useIntern enable jvm string intern method
 	 */
 	public HTMLSchema(final boolean useIntern) {

--- a/core/templates/HTMLSchema.java
+++ b/core/templates/HTMLSchema.java
@@ -30,17 +30,6 @@ public class HTMLSchema extends Schema implements HTMLModels {
 
 	/**
 	 * Returns a newly constructed HTMLSchema object independent of any existing ones.
-	 */
-	public HTMLSchema() {
-		// Enable JVM string intern.
-		setUseIntern(true);
-		// Start of Schema calls
-		@@SCHEMA_CALLS@@
-		// End of Schema calls
-	}
-
-	/**
-	 * Returns a newly constructed HTMLSchema object independent of any existing ones.
 	 * @param useIntern enable jvm string intern method
 	 */
 	public HTMLSchema(final boolean useIntern) {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.yahoo.tagchowder</groupId>
     <artifactId>tagchowder</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.15</version>
+    <version>2.0.16</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/tagchowder</url>
     <description>Parent POM file for tagchowder project</description>


### PR DESCRIPTION
1. Reduce default buffer size to 2KB
2. Keep HTMLSchema() constructor to avoid breaking compatibility

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
